### PR TITLE
Add resource clump destruction sync

### DIFF
--- a/StardewValleyMP/Multiplayer.cs
+++ b/StardewValleyMP/Multiplayer.cs
@@ -781,6 +781,11 @@ namespace StardewValleyMP
         public static bool hadDancePartner = false;
         public static string prevSpouse = null;
         public static int prevBooks = 0;
+		private static bool rcInit = false;
+        private static bool rcLastLogState = true;
+        private static List<int> rcLastWoodsState = new List<int>();
+        private static List<int> rcLastFarmState = new List<int>();
+		
         public static void doMyPlayerUpdates(byte id)
         {
             MovingStatePacket currMoving = new MovingStatePacket(id, Game1.player);
@@ -844,6 +849,59 @@ namespace StardewValleyMP
                 sendFunc(new LostBooksPacket());
             }
             prevBooks = Game1.player.archaeologyFound.ContainsKey(102) ? Game1.player.archaeologyFound[102][0] : 0;
+			
+			//begin synchronize resource clump destruction
+			bool rcCurrLogState = (((Forest)Game1.getLocationFromName("Forest")).log != null);
+            if (!rcInit)
+            {
+                rcLastLogState = rcCurrLogState;
+                rcInit = true;
+            }
+            if(rcCurrLogState == false &&  rcLastLogState == true)
+            {
+                //hash doesn't matter for the forest map
+                sendFunc(new ResourceClumpsPacket(ResourceClumpsPacket.MAP_FOREST, 0));
+            }
+            rcLastLogState = rcCurrLogState;
+
+            //section B: woods stumps
+            Woods map_woods = (Woods)Game1.getLocationFromName("Woods");
+            List<int> woodsState = new List<int>();
+            for (int i = 0; i <= map_woods.stumps.Count - 1; i++)
+            {
+                int vx = map_woods.stumps[i].getBoundingBox(map_woods.stumps[i].tile).X;
+                int vy = map_woods.stumps[i].getBoundingBox(map_woods.stumps[i].tile).Y;
+                woodsState.Add(ResourceClumpsPacket.hashVec2(vx, vy));
+            }
+            foreach(int hash in rcLastWoodsState)
+            {
+                //we are looking for stumps that were there last frame but are not now
+                if (!woodsState.Contains(hash))
+                {
+                    sendFunc(new ResourceClumpsPacket(ResourceClumpsPacket.MAP_WOODS, hash));
+                }
+            }
+            rcLastWoodsState = woodsState;
+
+            //section C: farm resourceclumps
+            Farm map_farm = (Farm)Game1.getLocationFromName("Farm");
+            List<int> farmState = new List<int>();
+            for (int i = 0; i <= map_farm.resourceClumps.Count - 1; i++)
+            {
+                int vx = map_farm.resourceClumps[i].getBoundingBox(map_farm.resourceClumps[i].tile).X;
+                int vy = map_farm.resourceClumps[i].getBoundingBox(map_farm.resourceClumps[i].tile).Y;
+                farmState.Add(ResourceClumpsPacket.hashVec2(vx, vy));
+            }
+            foreach (int hash in rcLastFarmState)
+            {
+                //we are looking for resource clumps that were there last frame but are not now
+                if (!farmState.Contains(hash))
+                {
+                    sendFunc(new ResourceClumpsPacket(ResourceClumpsPacket.MAP_FARM, hash));
+                }
+            }
+            rcLastFarmState = farmState;
+			//end synchronize resource clump destruction
         }
     }
 }

--- a/StardewValleyMP/Packets/Packet.cs
+++ b/StardewValleyMP/Packets/Packet.cs
@@ -53,6 +53,7 @@ namespace StardewValleyMP.Packets
         FarmAnimal,
         LatestId,
         LostBooks,
+		ResourceClumps,
         // Stuff...
     };
 
@@ -118,6 +119,7 @@ namespace StardewValleyMP.Packets
                 case (byte)ID.FarmAnimal: packet = new FarmAnimalPacket(); break;
                 case (byte)ID.LatestId: packet = new LatestIdPacket(); break;
                 case (byte)ID.LostBooks: packet = new LostBooksPacket(); break;
+				case (byte)ID.ResourceClumps: packet = new ResourceClumpsPacket(0, 0); break;
             }
 
             if (packet == null)

--- a/StardewValleyMP/Packets/ResourceClumpsPacket.cs
+++ b/StardewValleyMP/Packets/ResourceClumpsPacket.cs
@@ -1,0 +1,109 @@
+﻿//zzhack
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using StardewValley;
+using StardewValley.Locations;
+using StardewValley.TerrainFeatures;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+
+namespace StardewValleyMP.Packets
+{
+    // Server <-> Client
+    // Synchronize the state of ResourceClumps (hardwood logs, meteorite, boulders, etc)
+    public class ResourceClumpsPacket : Packet
+    {
+        public byte map;
+        public int hash;
+
+        public const byte MAP_WOODS = 0;
+        public const byte MAP_FOREST = 1;
+        public const byte MAP_FARM = 2;
+
+        public ResourceClumpsPacket(byte map, int hash)
+            : base(ID.ResourceClumps)
+        {
+            this.map = map;
+            this.hash = hash;
+        }
+
+        public static int hashVec2(int x, int y)
+        {
+            int res = 17;
+            res = ((res + x) << 5) - (res + x);
+            res = ((res + y) << 5) - (res + y);
+            return res;
+        }
+
+        protected override void read(BinaryReader reader)
+        {
+            map = reader.ReadByte();
+            hash = reader.ReadInt32();
+        }
+
+        protected override void write(BinaryWriter writer)
+        {
+            writer.Write(map);
+            writer.Write(hash);
+        }
+
+        public override void process(Client client)
+        {
+            process();
+        }
+
+        public override void process(Server server, Server.Client client)
+        {
+            process();
+            server.broadcast(this, client.id);
+        }
+
+        private void process()
+        {
+
+            switch (map)
+            {
+                case MAP_FOREST:
+                    //only the log here, sooo.
+                    ((Forest)Game1.getLocationFromName("Forest")).log = null;
+                    break;
+                case MAP_WOODS:
+                    //check the stumps in the woods
+                    Woods map_woods = (Woods)Game1.getLocationFromName("Woods");
+                    for (int i = 0; i <= map_woods.stumps.Count - 1; i++)
+                    {
+                        int vx = map_woods.stumps[i].getBoundingBox(map_woods.stumps[i].tile).X;
+                        int vy = map_woods.stumps[i].getBoundingBox(map_woods.stumps[i].tile).Y;
+                        if (hashVec2(vx, vy) == hash)
+                        {
+                            //we have found a removed stump! let's kill it :D
+                            map_woods.stumps.RemoveAt(i);
+                        }
+                    }
+                    break;
+                case MAP_FARM:
+                    //check the resource clumps on the farm
+                    Farm map_farm = (Farm)Game1.getLocationFromName("Farm");
+                    for (int i = 0; i <= map_farm.resourceClumps.Count - 1; i++)
+                    {
+                        int vx = map_farm.resourceClumps[i].getBoundingBox(map_farm.resourceClumps[i].tile).X;
+                        int vy = map_farm.resourceClumps[i].getBoundingBox(map_farm.resourceClumps[i].tile).Y;
+                        if (hashVec2(vx, vy) == hash)
+                        {
+                            //we have found a removed resource clump! let's kill it :D
+                            map_farm.resourceClumps.RemoveAt(i);
+                        }
+                    }
+                    break;
+            }
+
+
+
+        }
+
+    }
+}

--- a/StardewValleyMP/StardewValleyMP.csproj
+++ b/StardewValleyMP/StardewValleyMP.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Packets\BuildingPacket.cs" />
     <Compile Include="Packets\TimeSyncPacket.cs" />
     <Compile Include="Packets\PauseTimePacket.cs" />
+    <Compile Include="Packets\ResourceClumpsPacket.cs" />
     <Compile Include="Packets\CoopUpdatePacket.cs" />
     <Compile Include="Packets\NextDayPacket.cs" />
     <Compile Include="Packets\LatestIdPacket.cs" />


### PR DESCRIPTION
Fixes #5 .

Uses a new packet, ResourceClumpsPacket to send destruction events for ResourceClump objects.

This one was a bit tricky because the objects are handled in different ways on different maps- there was nothing generic about ResourceClumps.  This setup handles the Woods (Secret Woods), Forest (the map with the big lake and Marnie's house in it), and the Farm.

The Mines were ignored because nothing there is really synced at all anyway (and there are other issues that would need to be tackled to sync that, before this is even an issue).

Mods that add new ResourceClumps are likely not going to sync, but I don't believe this will cause any further issues with them.  Adding stumps in the Woods, or anything on the Farm should automatically be handled, assuming you use the existing lists.

Because the various stumps/etc don't have actual "id"s, I kind of made my own by using a simple hash on the object's coordinates.  Collisions should be extremely rare (practically nonexistant in this scenario, where we're only talking a handful of objects.)  I wanted to do it in a way that would allow -some- mods to work, and this was the most flexible solution I could come up with.

Edit: If you'd like this organized differently, feel free to rip the code and implement it as you like :)  I had some conflicting thoughts about where to put the monitoring code, ended up leaving it there in Multiplayer.cs.